### PR TITLE
escape filename since backslash make problems on Windows

### DIFF
--- a/plugin/fetch.vim
+++ b/plugin/fetch.vim
@@ -24,7 +24,7 @@ if has('autocmd')
       "
       " 1. check new files for a spec when Vim has finished its init sequence...
       autocmd BufNewFile *
-      \ execute 'autocmd fetch VimEnter * nested call fetch#buffer("'.expand('<afile>').'")'
+      \ execute 'autocmd fetch VimEnter * nested call fetch#buffer("'.escape(expand('<afile>'), ' \\').'")'
       " 2. ... and start checking directly once the init sequence is complete
       autocmd VimEnter *
       \ execute 'autocmd! fetch BufNewFile * nested call fetch#buffer(expand("<afile>"))'


### PR DESCRIPTION
Using vim-fetch on Windows, and open a file with vim `~/_vimrc:20`. If you use noshellslash (default), the filename will be handled as `~\_vimrc:20`. So this backslash break vim-fetch.