### PR TITLE
Better grep format handling

### DIFF
--- a/autoload/fetch.vim
+++ b/autoload/fetch.vim
@@ -10,7 +10,7 @@ set cpoptions&vim
 let s:specs = {}
 
 " - trailing colon, i.e. ':lnum[:colnum[:]]'
-let s:specs.colon = {'pattern': '\m\%(:\d\+\)\{1,2}:\?'}
+let s:specs.colon = {'pattern': '\m\%(:\d\+\)\{1,2}\%(:.*\)\?'}
 function! s:specs.colon.parse(file) abort
   let l:file = substitute(a:file, self.pattern, '', '')
   let l:pos  = split(matchstr(a:file, self.pattern), ':')


### PR DESCRIPTION
my grep (and git grep) configuration produce the following output:
path/to/file:123:some text here

The grepped text follows the last colon, without any space. When I
double click on my terminal, it stops at first space, then my following
line would be:
vim path/to/file:123:some

Current regex pattern recognizes this text as valid, but the len is not
valid.

This patch takes into account the potential text following the last
colon.