### PR TITLE
Add specs for grep context and git grep function context lines

### DIFF
--- a/autoload/fetch.vim
+++ b/autoload/fetch.vim
@@ -25,6 +25,22 @@ function! s:specs.paren.parse(file) abort
   return [l:file, ['cursor', [l:pos[0], get(l:pos, 1, 0)]]]
 endfunction
 
+" - trailing equals, i.e. '=lnum='
+let s:specs.equals = {'pattern': '\m=\(\d\+\)=\%(.*\)\?'}
+function! s:specs.equals.parse(file) abort
+  let l:file = substitute(a:file, self.pattern, '', '')
+  let l:pos  = matchlist(a:file, self.pattern)[1]
+  return [l:file, ['cursor', [l:pos, 0]]]
+endfunction
+
+" - trailing dash, i.e. '-lnum-'
+let s:specs.dash = {'pattern': '\m-\(\d\+\)-\%(.*\)\?'}
+function! s:specs.dash.parse(file) abort
+  let l:file = substitute(a:file, self.pattern, '', '')
+  let l:pos  = matchlist(a:file, self.pattern)[1]
+  return [l:file, ['cursor', [l:pos, 0]]]
+endfunction
+
 " - Plan 9 type line spec, i.e. '[:]#lnum'
 let s:specs.plan9 = {'pattern': '\m:#\(\d\+\)'}
 function! s:specs.plan9.parse(file) abort

--- a/doc/vim-fetch.txt
+++ b/doc/vim-fetch.txt
@@ -43,9 +43,15 @@ PARENTHESES ENCLOSED
 6. path/to/file.ext(lnum:colnum)
 
 
+EQUALS/DASH ENCLOSED
+
+7. path/to/file.ext=lnum=
+8. path/to/file.ext-lnum-
+
+
 PLAN 9 STYLE
 
-7. path/to/file.ext:#lnum
+9. path/to/file.ext:#lnum
 
 Note: `#` is the alternate file token and needs to be escaped to be used on
 the command line (see |cmdline-special|).
@@ -53,7 +59,7 @@ the command line (see |cmdline-special|).
 
 PYTEST METHOD JUMPS
 
-8. path/to/file.ext::method
+10. path/to/file.ext::method
 
 Note: this will only find Python method definitions.
 


### PR DESCRIPTION
When called with the `-A`, `-B` or `-C` flags, `grep` and `git grep` show
the line number for context lines enclosed with dashes, for example:

    $ grep -r -A 2 -n spec .
    ./autoload/fetch.vim:9:" Position specs Dictionary: {{{
    ./autoload/fetch.vim:10:let s:specs = {}
    ./autoload/fetch.vim-11-
    ./autoload/fetch.vim-12-" - trailing colon, i.e. ':lnum[:colnum[:]]'

Similarly, `git grep`, when called with the `-p` flag, shows the line
number for the nearest function line enclosed with equal signs, for example:

    $ git grep -p show-function
    builtin/grep.c=796=int cmd_grep(int argc, const char **argv, const char *prefix)
    builtin/grep.c:894:     OPT_BOOL('p', "show-function", &opt.funcname,

This PR adds specs for these two cases.