### PR TITLE
Support trailing garbage on line.

### DIFF
--- a/autoload/fetch.vim
+++ b/autoload/fetch.vim
@@ -10,11 +10,11 @@ set cpoptions&vim
 let s:specs = {}
 
 " - trailing colon, i.e. ':lnum[:colnum[:]]'
-let s:specs.colon = {'pattern': '\m\%(:\d\+\)\{1,2}\%(:.*\)\?'}
+let s:specs.colon = {'pattern': '\m\%(:\d*\)\{1,2}\%(.*\)\?'}
 function! s:specs.colon.parse(file) abort
   let l:file = substitute(a:file, self.pattern, '', '')
   let l:pos  = split(matchstr(a:file, self.pattern), ':')
-  return [l:file, ['cursor', [l:pos[0], get(l:pos, 1, 0)]]]
+  return [l:file, ['cursor', [get(l:pos, 0, 0), get(l:pos, 1, 0)]]]
 endfunction
 
 " - trailing parentheses, i.e. '(lnum[:colnum])'


### PR DESCRIPTION
E.g if someone does a grep and gets output like this:

```
$ grep -r TODO
myfile:TODO add some stuff
otherfile:TODO other stuff
```

Then I like to just choose a file by double clicking the name and writing e.g. `vim myfile:TODO` without having to erase the TODO bit.

This is accomplished by allowing zero digits in the line number.