### PR TITLE
Implemented support for GitHub / GitLab line jump specifications

### DIFF
--- a/autoload/fetch.vim
+++ b/autoload/fetch.vim
@@ -58,6 +58,13 @@ function! s:specs.pytest.parse(file) abort
   return [l:file, ['search', [l:method, 'cw']]]
 endfunction " }}}
 
+" - GitHub line spec, i.e. '#Llnum'
+let s:specs.github_line = {'pattern': '\m#L\(\d\+\)'}
+function! s:specs.github_line.parse(file) abort
+  let l:file = substitute(a:file, self.pattern, '', '')
+  let l:pos  = matchlist(a:file, self.pattern)[1]
+  return [l:file, ['cursor', [l:pos, 0]]]
+endfunction
 " Detection heuristics for buffers that should not be resolved: {{{
 let s:bufignore = {'freaks': []}
 function! s:bufignore.detect(bufnr) abort

--- a/autoload/fetch.vim
+++ b/autoload/fetch.vim
@@ -65,6 +65,15 @@ function! s:specs.github_line.parse(file) abort
   let l:pos  = matchlist(a:file, self.pattern)[1]
   return [l:file, ['cursor', [l:pos, 0]]]
 endfunction
+
+" - GitHub line range, i.e. '#Llnum-Llnum'
+let s:specs.github_range = {'pattern': '\m#L\(\d\+\)-L\(\d\+\)'}
+function! s:specs.github_range.parse(file) abort
+  let l:file = substitute(a:file, self.pattern, '', '')
+  let [l:start, l:end]  = matchlist(a:file, self.pattern)[1:2]
+  return [l:file, ['execute', ['normal! '.l:end.'GV'.l:start.'Ggv0']]]
+endfunction
+
 " Detection heuristics for buffers that should not be resolved: {{{
 let s:bufignore = {'freaks': []}
 function! s:bufignore.detect(bufnr) abort
@@ -277,7 +286,8 @@ function! s:setpos(calldata) abort
   call s:doautocmd('BufFetchPosPre')
   keepjumps call call('call', a:calldata)
   let b:fetch_lastpos = getpos('.')[1:2]
-  silent! normal! zOzz
+  silent! foldopen!
+  silent! normal! zz
   call s:doautocmd('BufFetchPosPost')
   return 1
 endfunction

--- a/autoload/fetch.vim
+++ b/autoload/fetch.vim
@@ -58,7 +58,7 @@ function! s:specs.pytest.parse(file) abort
   return [l:file, ['search', [l:method, 'cw']]]
 endfunction " }}}
 
-" - GitHub line spec, i.e. '#Llnum'
+" - GitHub/GitLab line spec, i.e. '#Llnum'
 let s:specs.github_line = {'pattern': '\m#L\(\d\+\)'}
 function! s:specs.github_line.parse(file) abort
   let l:file = substitute(a:file, self.pattern, '', '')
@@ -66,8 +66,8 @@ function! s:specs.github_line.parse(file) abort
   return [l:file, ['cursor', [l:pos, 0]]]
 endfunction
 
-" - GitHub line range, i.e. '#Llnum-Llnum'
-let s:specs.github_range = {'pattern': '\m#L\(\d\+\)-L\(\d\+\)'}
+" - GitHub/GitLab line range, i.e. '#Llnum-Llnum'
+let s:specs.github_range = {'pattern': '\m#L\(\d\+\)-L\?\(\d\+\)'}
 function! s:specs.github_range.parse(file) abort
   let l:file = substitute(a:file, self.pattern, '', '')
   let [l:start, l:end]  = matchlist(a:file, self.pattern)[1:2]


### PR DESCRIPTION
Introduced support for two distinct line jump specifications used by GitHub and GitLab:

- Line *jump* specification is implemented in a very similar fashion to all the other line jump specifications.

  GitHub / GitLab example: `autoload/fetch.vim#L6`

- Line *range* specification is implemented by relying on normal mode commands. 

  When opening a line range vim will enter linewise Visual mode and pre-select all the lines in the range. The cursor will be placed at the start of the selected range.
  
  However `zO`, used with in [`s:setpos`](https://github.com/wsdjeg/vim-fetch/blob/master/autoload/fetch.vim#L273) caused vim to drop out of Visual mode, thus loosing the selection. To fix that, I've replaced it with `foldopen!`.

  GitHub example: `autoload/fetch.vim#L6-L10`
  GitLab example: `autoload/fetch.vim#L6-10`
  