### PR TITLE
Make vim-fetch work as expected when using autochdir

### DIFF
--- a/plugin/fetch.vim
+++ b/plugin/fetch.vim
@@ -24,10 +24,10 @@ if has('autocmd')
       "
       " 1. check new files for a spec when Vim has finished its init sequence...
       autocmd BufNewFile *
-      \ execute 'autocmd fetch VimEnter * nested call fetch#buffer("'.escape(expand('<afile>'), ' \\').'")'
+      \ execute 'autocmd fetch VimEnter * nested call fetch#buffer("'.escape(expand('<afile>:p'), ' \\').'")'
       " 2. ... and start checking directly once the init sequence is complete
       autocmd VimEnter *
-      \ execute 'autocmd! fetch BufNewFile * nested call fetch#buffer(expand("<afile>"))'
+      \ execute 'autocmd! fetch BufNewFile * nested call fetch#buffer(expand("<afile>:p"))'
 
       " `fetch#buffer` is tab-local, so let's process buffers on other tab pages;
       " as of Vim 8.1522, I can't think of a way to create two or more windows


### PR DESCRIPTION
I used this plugin for years without any issues with version 2.0.2 (ce1bfad), I recently upgraded to bbb75c3172f766d1a62832df0ec7674c69a560ad where I noticed that `vim-fetch` stopped working as expected.

Here's a repro (importantly it needs `set autochdir`):

```
$ cat >a <<EOF
a
b
c
EOF
$ mkdir b
$ cp a b/
$ vim a:2 # works
$ vim b/a:2 # does not work, the opened buffer is `b/a:2` instead of the expected `b/a`
$
```

After `git bisect`ing, I found that ef8a8e7 introduced the breaking change.

Digging some more it looks like the issue is around here:

https://github.com/wsdjeg/vim-fetch/blob/bbb75c3172f766d1a62832df0ec7674c69a560ad/autoload/fetch.vim#L143-L145

Given that `autochdir` is being used, the current working directory (`getcwd()`) is effectively set to `b/` and from there `b/a` is *not* readable.

As a fix, we can use the `:p` modifier when calling `expand` which makes `vim-fetch` rely on absolute paths and therefore whether `autochdir` is used or not becomes irrelevant. I can't think of any downsides to this approach but I have little to no experience with VimL beyond maintaining my own `.vimrc`. 