### PR TITLE
Fix error when opening new files containing quotes

### DIFF
--- a/plugin/fetch.vim
+++ b/plugin/fetch.vim
@@ -24,7 +24,7 @@ if has('autocmd')
       "
       " 1. check new files for a spec when Vim has finished its init sequence...
       autocmd BufNewFile *
-      \ execute 'autocmd fetch VimEnter * nested call fetch#buffer("'.escape(expand('<afile>:p'), ' \\').'")'
+      \ execute 'autocmd fetch VimEnter * nested call fetch#buffer("'.escape(expand('<afile>:p'), ' \\"').'")'
       " 2. ... and start checking directly once the init sequence is complete
       autocmd VimEnter *
       \ execute 'autocmd! fetch BufNewFile * nested call fetch#buffer(expand("<afile>:p"))'


### PR DESCRIPTION
`vim-fetch` gave this error when opening a new file that contained quotes:

    Error detected while processing VimEnter Autocommands for "*":
    E116: Invalid arguments for function fetch#buffer

For example, `vim '"ok".txt'` would give an error if `"ok".txt` didn't exist.

This was happening because the quotes weren't being properly escaped. This fixes that and removes the error.

I tested this with my personal configuration and on a completely fresh virtual machine.